### PR TITLE
do not write if no change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   mode is active, a new message ("dry-run: no files will be written") is shown
   before the regular output.
 
+### Fixed
+
+- Files will not be overwritten if there is no change to be made.
+
 ## [0.1.0] - 2023-08-09
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+- The output will not be different between regular and dry-run mode.
+
+  Prior to this, when the tool was run in dry-run mode, it would output "would
+  write" and "would overwrite" instead of "writing" and "overwriting". The tool
+  will now always output "writing" and "overwriting". To indicate that dry-run
+  mode is active, a new message ("dry-run: no files will be written") is shown
+  before the regular output.
+
 ## [0.1.0] - 2023-08-09
 
 Initial release.

--- a/testing/files.py
+++ b/testing/files.py
@@ -17,6 +17,12 @@ class FakeFileSystem:
         except KeyError:
             return []
 
+    def read_content(self, file_path: str) -> str:
+        try:
+            return self.files[file_path]
+        except KeyError:
+            return ''
+
     def write_file(self, path: str, content: str, is_executable: bool) -> None:
         self.files[path] = content
         if is_executable:

--- a/testing/files.py
+++ b/testing/files.py
@@ -7,7 +7,7 @@ import attrs
 class MemoryReader:
     files: dict[str, list[str]]
 
-    def load_file(self, file_path: str) -> list[str]:
+    def read_lines(self, file_path: str) -> list[str]:
         try:
             return self.files[file_path]
         except KeyError:

--- a/testing/files.py
+++ b/testing/files.py
@@ -4,23 +4,18 @@ import attrs
 
 
 @attrs.frozen
-class MemoryReader:
-    files: dict[str, list[str]]
-
-    def read_lines(self, file_path: str) -> list[str]:
-        try:
-            return self.files[file_path]
-        except KeyError:
-            return []
-
-
-@attrs.frozen
-class FakeFileWriter:
+class FakeFileSystem:
     files: dict[str, str] = attrs.field(factory=dict)
     executables: list[str] = attrs.field(factory=list)
 
     def file_exists(self, path: str) -> bool:
         return path in self.files
+
+    def read_lines(self, file_path: str) -> list[str]:
+        try:
+            return self.files[file_path].splitlines(keepends=True)
+        except KeyError:
+            return []
 
     def write_file(self, path: str, content: str, is_executable: bool) -> None:
         self.files[path] = content

--- a/tests/cli/write_test.py
+++ b/tests/cli/write_test.py
@@ -12,21 +12,25 @@ PLAIN_FILE_CONTENT = """\
 some text and a newline
 """
 
+TEMPLATE_CONTENT = """\
+some new text and a newline
+"""
+
 
 def _setup(template_dir: Path, output_dir: Path, tmp_path: Path) -> tuple[Path, Path]:
     new_template = template_dir / 'new_file.txt'
-    new_template.write_text(PLAIN_FILE_CONTENT)
+    new_template.write_text(TEMPLATE_CONTENT)
 
     existing_template = template_dir / 'existing_file.txt'
-    existing_template.write_text(PLAIN_FILE_CONTENT)
+    existing_template.write_text(TEMPLATE_CONTENT)
     existing_file = output_dir / 'existing_file.txt'
     existing_file.write_text(PLAIN_FILE_CONTENT)
 
     custom_subdir_template = template_dir / 'file_in_custom_subdir.txt'
-    custom_subdir_template.write_text(PLAIN_FILE_CONTENT)
+    custom_subdir_template.write_text(TEMPLATE_CONTENT)
 
     abs_path_template = template_dir / 'file_with_abs_path.txt'
-    abs_path_template.write_text(PLAIN_FILE_CONTENT)
+    abs_path_template.write_text(TEMPLATE_CONTENT)
 
     templates_file = tmp_path / 'templates.yaml'
     templates_file.write_text(

--- a/tests/cli/write_test.py
+++ b/tests/cli/write_test.py
@@ -148,6 +148,7 @@ def test_write_dry_run(
     assert (
         captured.err
         == f"""\
+\033[0mdry-run: no files will be written\033[0m
 \033[0mwriting {output_dir}/new_file.txt\033[0m
 \033[2mskipping {output_dir}/existing_file.txt because it already exists\033[0m
 \033[0mwriting {output_dir}/subdir/custom.txt\033[0m
@@ -175,6 +176,7 @@ def test_write_force_dry_run(
     assert (
         captured.err
         == f"""\
+\033[0mdry-run: no files will be written\033[0m
 \033[0mwriting {output_dir}/new_file.txt\033[0m
 \033[93moverwriting {output_dir}/existing_file.txt\033[0m
 \033[0mwriting {output_dir}/subdir/custom.txt\033[0m

--- a/tests/cli/write_test.py
+++ b/tests/cli/write_test.py
@@ -148,10 +148,10 @@ def test_write_dry_run(
     assert (
         captured.err
         == f"""\
-\033[0mwould write {output_dir}/new_file.txt\033[0m
+\033[0mwriting {output_dir}/new_file.txt\033[0m
 \033[2mskipping {output_dir}/existing_file.txt because it already exists\033[0m
-\033[0mwould write {output_dir}/subdir/custom.txt\033[0m
-\033[0mwould write /{template_dir}/elsewhere/absolute.txt\033[0m
+\033[0mwriting {output_dir}/subdir/custom.txt\033[0m
+\033[0mwriting /{template_dir}/elsewhere/absolute.txt\033[0m
 """
     )
 
@@ -175,9 +175,9 @@ def test_write_force_dry_run(
     assert (
         captured.err
         == f"""\
-\033[0mwould write {output_dir}/new_file.txt\033[0m
-\033[93mwould overwrite {output_dir}/existing_file.txt\033[0m
-\033[0mwould write {output_dir}/subdir/custom.txt\033[0m
-\033[0mwould write /{template_dir}/elsewhere/absolute.txt\033[0m
+\033[0mwriting {output_dir}/new_file.txt\033[0m
+\033[93moverwriting {output_dir}/existing_file.txt\033[0m
+\033[0mwriting {output_dir}/subdir/custom.txt\033[0m
+\033[0mwriting /{template_dir}/elsewhere/absolute.txt\033[0m
 """
     )

--- a/tests/commands/diff_test.py
+++ b/tests/commands/diff_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from testing.files import MemoryReader
+from testing.files import FakeFileSystem
 from testing.printing import CapturedPrinter
 from testing.rendering import FakeRenderer
 from write_config_files.commands.diff import Differ
@@ -9,7 +9,7 @@ from write_config_files.config import TemplateFile
 
 
 def test_diff_when_no_change():
-    reader = MemoryReader(files={'no-change': ['file content\n']})
+    reader = FakeFileSystem(files={'no-change': 'file content\n'})
     printer = CapturedPrinter()
 
     templates = TemplateConfig(
@@ -28,7 +28,7 @@ def test_diff_when_no_change():
 
 
 def test_diff_when_file_changed():
-    reader = MemoryReader(files={'has-change': ['different content\n']})
+    reader = FakeFileSystem(files={'has-change': 'different content\n'})
     printer = CapturedPrinter()
 
     templates = TemplateConfig(
@@ -55,7 +55,7 @@ def test_diff_when_file_changed():
 
 
 def test_diff_for_new_file():
-    reader = MemoryReader(files={})
+    reader = FakeFileSystem(files={})
     printer = CapturedPrinter()
 
     templates = TemplateConfig(

--- a/tests/commands/write_test.py
+++ b/tests/commands/write_test.py
@@ -99,6 +99,35 @@ def test_overwrite_existing_file():
     }
 
 
+def test_skip_unchanged_file():
+    file_system = FakeFileSystem(files={'output/existing-file': 'some content'})
+    logger = CapturedLogger()
+
+    templates = TemplateConfig(
+        root_dir='',
+        files=(
+            TemplateFile('templates/existing-file', 'output/existing-file', False),
+        ),
+    )
+
+    writer = Writer(
+        renderer=FakeRenderer('some content'),
+        file_system=file_system,
+        logger=logger,
+    )
+    writer.write(templates=templates, skip_if_exists=False)
+
+    assert file_system.files == {
+        'output/existing-file': 'some content',  # same content
+    }
+
+    assert logger.captured == {
+        'debug': ['skipping output/existing-file because there are no changes'],
+        'info': [],
+        'warn': [],
+    }
+
+
 def test_skip_existing_file():
     file_system = FakeFileSystem(files={'output/existing-file': ''})
     logger = CapturedLogger()

--- a/tests/commands/write_test.py
+++ b/tests/commands/write_test.py
@@ -35,7 +35,7 @@ def test_write_file():
 
     assert logger.captured == {
         'debug': [],
-        'info': [],
+        'info': ['writing output/config-file', 'writing output/settings-file'],
         'warn': [],
     }
 
@@ -65,7 +65,7 @@ def test_write_executable_file():
 
     assert logger.captured == {
         'debug': [],
-        'info': [],
+        'info': ['writing output/a-script'],
         'warn': [],
     }
 
@@ -95,7 +95,7 @@ def test_overwrite_existing_file():
     assert logger.captured == {
         'debug': [],
         'info': [],
-        'warn': [],
+        'warn': ['overwriting output/existing-file'],
     }
 
 

--- a/tests/commands/write_test.py
+++ b/tests/commands/write_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from testing.files import FakeFileWriter
+from testing.files import FakeFileSystem
 from testing.logging import CapturedLogger
 from testing.rendering import FakeRenderer
 from write_config_files.commands.write import Writer
@@ -9,7 +9,7 @@ from write_config_files.config import TemplateFile
 
 
 def test_write_file():
-    file_writer = FakeFileWriter()
+    file_writer = FakeFileSystem()
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -41,7 +41,7 @@ def test_write_file():
 
 
 def test_write_executable_file():
-    file_writer = FakeFileWriter()
+    file_writer = FakeFileSystem()
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -71,7 +71,7 @@ def test_write_executable_file():
 
 
 def test_overwrite_existing_file():
-    file_writer = FakeFileWriter(files={'output/existing-file': ''})
+    file_writer = FakeFileSystem(files={'output/existing-file': ''})
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -100,7 +100,7 @@ def test_overwrite_existing_file():
 
 
 def test_skip_existing_file():
-    file_writer = FakeFileWriter(files={'output/existing-file': ''})
+    file_writer = FakeFileSystem(files={'output/existing-file': ''})
     logger = CapturedLogger()
 
     templates = TemplateConfig(

--- a/tests/commands/write_test.py
+++ b/tests/commands/write_test.py
@@ -9,7 +9,7 @@ from write_config_files.config import TemplateFile
 
 
 def test_write_file():
-    file_writer = FakeFileSystem()
+    file_system = FakeFileSystem()
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -22,16 +22,16 @@ def test_write_file():
 
     writer = Writer(
         renderer=FakeRenderer('some content'),
-        file_writer=file_writer,
+        file_system=file_system,
         logger=logger,
     )
     writer.write(templates=templates, skip_if_exists=False)
 
-    assert file_writer.files == {
+    assert file_system.files == {
         'output/config-file': 'some content',
         'output/settings-file': 'some content',
     }
-    assert file_writer.executables == []
+    assert file_system.executables == []
 
     assert logger.captured == {
         'debug': [],
@@ -41,7 +41,7 @@ def test_write_file():
 
 
 def test_write_executable_file():
-    file_writer = FakeFileSystem()
+    file_system = FakeFileSystem()
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -53,15 +53,15 @@ def test_write_executable_file():
 
     writer = Writer(
         renderer=FakeRenderer('some content'),
-        file_writer=file_writer,
+        file_system=file_system,
         logger=logger,
     )
     writer.write(templates=templates, skip_if_exists=False)
 
-    assert file_writer.files == {
+    assert file_system.files == {
         'output/a-script': 'some content',
     }
-    assert file_writer.executables == ['output/a-script']
+    assert file_system.executables == ['output/a-script']
 
     assert logger.captured == {
         'debug': [],
@@ -71,7 +71,7 @@ def test_write_executable_file():
 
 
 def test_overwrite_existing_file():
-    file_writer = FakeFileSystem(files={'output/existing-file': ''})
+    file_system = FakeFileSystem(files={'output/existing-file': ''})
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -83,12 +83,12 @@ def test_overwrite_existing_file():
 
     writer = Writer(
         renderer=FakeRenderer('new content'),
-        file_writer=file_writer,
+        file_system=file_system,
         logger=logger,
     )
     writer.write(templates=templates, skip_if_exists=False)
 
-    assert file_writer.files == {
+    assert file_system.files == {
         'output/existing-file': 'new content',  # new content written
     }
 
@@ -100,7 +100,7 @@ def test_overwrite_existing_file():
 
 
 def test_skip_existing_file():
-    file_writer = FakeFileSystem(files={'output/existing-file': ''})
+    file_system = FakeFileSystem(files={'output/existing-file': ''})
     logger = CapturedLogger()
 
     templates = TemplateConfig(
@@ -112,12 +112,12 @@ def test_skip_existing_file():
 
     writer = Writer(
         renderer=FakeRenderer('some content'),
-        file_writer=file_writer,
+        file_system=file_system,
         logger=logger,
     )
     writer.write(templates=templates, skip_if_exists=True)
 
-    assert file_writer.files == {
+    assert file_system.files == {
         'output/existing-file': '',  # not changed
     }
 

--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -21,7 +21,7 @@ class TestFileSystem:
 
         assert logger.captured == {
             'debug': [],
-            'info': [f'writing {output_file}'],
+            'info': [],
             'warn': [],
         }
 
@@ -42,7 +42,7 @@ class TestFileSystem:
         assert logger.captured == {
             'debug': [],
             'info': [],
-            'warn': [f'overwriting {output_file}'],
+            'warn': [],
         }
 
     def test_make_file_executable(self, tmp_path: Path):

--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -4,16 +4,16 @@ import os
 from pathlib import Path
 
 from testing.logging import CapturedLogger
-from write_config_files.files import OsFileWriter
+from write_config_files.files import FileSystem
 
 
-class TestOsFileWriter:
+class TestFileSystem:
     def test_write_new_file(self, tmp_path: Path):
         logger = CapturedLogger()
 
         output_file = tmp_path / 'output'
 
-        writer = OsFileWriter(logger)
+        writer = FileSystem(logger)
         writer.write_file(str(output_file), 'some content', is_executable=False)
 
         with open(output_file) as f:
@@ -33,7 +33,7 @@ class TestOsFileWriter:
         with open(output_file, 'w') as f:
             f.write('pre-existing content')
 
-        writer = OsFileWriter(logger)
+        writer = FileSystem(logger)
         writer.write_file(str(output_file), 'new content', is_executable=False)
 
         with open(output_file) as f:
@@ -50,7 +50,7 @@ class TestOsFileWriter:
 
         output_file = tmp_path / 'output'
 
-        writer = OsFileWriter(logger)
+        writer = FileSystem(logger)
         writer.write_file(str(output_file), 'some content', is_executable=True)
 
         # check the fiel is executable

--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -3,54 +3,35 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from testing.logging import CapturedLogger
 from write_config_files.files import FileSystem
 
 
 class TestFileSystem:
     def test_write_new_file(self, tmp_path: Path):
-        logger = CapturedLogger()
-
         output_file = tmp_path / 'output'
 
-        writer = FileSystem(logger)
+        writer = FileSystem()
         writer.write_file(str(output_file), 'some content', is_executable=False)
 
         with open(output_file) as f:
             assert f.read() == 'some content'
 
-        assert logger.captured == {
-            'debug': [],
-            'info': [],
-            'warn': [],
-        }
-
     def test_overwrite_existing_file(self, tmp_path: Path):
-        logger = CapturedLogger()
-
         output_file = tmp_path / 'output'
 
         with open(output_file, 'w') as f:
             f.write('pre-existing content')
 
-        writer = FileSystem(logger)
+        writer = FileSystem()
         writer.write_file(str(output_file), 'new content', is_executable=False)
 
         with open(output_file) as f:
             assert f.read() == 'new content'
 
-        assert logger.captured == {
-            'debug': [],
-            'info': [],
-            'warn': [],
-        }
-
     def test_make_file_executable(self, tmp_path: Path):
-        logger = CapturedLogger()
-
         output_file = tmp_path / 'output'
 
-        writer = FileSystem(logger)
+        writer = FileSystem()
         writer.write_file(str(output_file), 'some content', is_executable=True)
 
         # check the fiel is executable

--- a/write_config_files/cli.py
+++ b/write_config_files/cli.py
@@ -69,6 +69,7 @@ def write(
 
     file_system: FileSystem | DryRunFileWriter
     if dry_run:
+        logger.info('dry-run: no files will be written')
         file_system = DryRunFileWriter(logger)
     else:
         file_system = FileSystem(logger)

--- a/write_config_files/cli.py
+++ b/write_config_files/cli.py
@@ -13,8 +13,8 @@ from .commands.write import Writer
 from .config import TemplateConfig
 from .config import YamlParser
 from .files import DryRunFileWriter
+from .files import FileSystem
 from .files import FileSystemReader
-from .files import OsFileWriter
 from .logging import StdErrColorLogger
 from .logging import StdErrLogger
 from .printers import PagerPrinter
@@ -67,11 +67,11 @@ def write(
 
     logger = _get_logger()
 
-    file_writer: OsFileWriter | DryRunFileWriter
+    file_writer: FileSystem | DryRunFileWriter
     if dry_run:
         file_writer = DryRunFileWriter(logger)
     else:
-        file_writer = OsFileWriter(logger)
+        file_writer = FileSystem(logger)
 
     writer = Writer(renderer, file_writer, logger)
     writer.write(template_config, skip_if_exists=not force)

--- a/write_config_files/cli.py
+++ b/write_config_files/cli.py
@@ -14,7 +14,6 @@ from .config import TemplateConfig
 from .config import YamlParser
 from .files import DryRunFileWriter
 from .files import FileSystem
-from .files import FileSystemReader
 from .logging import StdErrColorLogger
 from .logging import StdErrLogger
 from .printers import PagerPrinter
@@ -88,7 +87,7 @@ def diff(
     template_config = _load_template_config(template_config_path)
     context = _load_context(context_file_path)
 
-    reader = FileSystemReader()
+    reader = FileSystem()
     renderer = _get_renderer(template_config, context)
 
     printer: StdOutPrinter | PagerPrinter

--- a/write_config_files/cli.py
+++ b/write_config_files/cli.py
@@ -70,9 +70,9 @@ def write(
     file_system: FileSystem | DryRunFileWriter
     if dry_run:
         logger.info('dry-run: no files will be written')
-        file_system = DryRunFileWriter(logger)
+        file_system = DryRunFileWriter()
     else:
-        file_system = FileSystem(logger)
+        file_system = FileSystem()
 
     writer = Writer(renderer, file_system, logger)
     writer.write(template_config, skip_if_exists=not force)

--- a/write_config_files/cli.py
+++ b/write_config_files/cli.py
@@ -67,13 +67,13 @@ def write(
 
     logger = _get_logger()
 
-    file_writer: FileSystem | DryRunFileWriter
+    file_system: FileSystem | DryRunFileWriter
     if dry_run:
-        file_writer = DryRunFileWriter(logger)
+        file_system = DryRunFileWriter(logger)
     else:
-        file_writer = FileSystem(logger)
+        file_system = FileSystem(logger)
 
-    writer = Writer(renderer, file_writer, logger)
+    writer = Writer(renderer, file_system, logger)
     writer.write(template_config, skip_if_exists=not force)
 
     return 0

--- a/write_config_files/commands/diff.py
+++ b/write_config_files/commands/diff.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import difflib
+from typing import Protocol
 
 import attrs
 
 from ..config import TemplateConfig
-from ..files import Reader
 from ..printers import DiffPrinter
 from ..rendering import TemplateRenderer
+
+
+class Reader(Protocol):
+    def load_file(self, file_path: str) -> list[str]: ...
 
 
 @attrs.frozen

--- a/write_config_files/commands/diff.py
+++ b/write_config_files/commands/diff.py
@@ -11,7 +11,7 @@ from ..rendering import TemplateRenderer
 
 
 class Reader(Protocol):
-    def load_file(self, file_path: str) -> list[str]: ...
+    def read_lines(self, file_path: str) -> list[str]: ...
 
 
 @attrs.frozen
@@ -22,7 +22,7 @@ class Differ:
 
     def print_diff(self, templates: TemplateConfig) -> None:
         for file in templates.files:
-            current_lines = self.reader.load_file(file.destination_path)
+            current_lines = self.reader.read_lines(file.destination_path)
 
             rendered_lines = (
                 self.renderer.render(file.template_name).splitlines(keepends=True)

--- a/write_config_files/commands/write.py
+++ b/write_config_files/commands/write.py
@@ -17,20 +17,20 @@ class FileSystem(Protocol):
 @attrs.frozen
 class Writer:
     renderer: TemplateRenderer
-    file_writer: FileSystem
+    file_system: FileSystem
     logger: Logger
 
     def write(self, templates: TemplateConfig, skip_if_exists: bool) -> None:
         for file in templates.files:
             rendered = self.renderer.render(file.template_name)
 
-            if skip_if_exists and self.file_writer.file_exists(file.destination_path):
+            if skip_if_exists and self.file_system.file_exists(file.destination_path):
                 self.logger.debug(
                     f'skipping {file.destination_path} because it already exists',
                 )
                 continue
 
-            self.file_writer.write_file(
+            self.file_system.write_file(
                 file.destination_path,
                 rendered,
                 file.is_executable,

--- a/write_config_files/commands/write.py
+++ b/write_config_files/commands/write.py
@@ -24,11 +24,17 @@ class Writer:
         for file in templates.files:
             rendered = self.renderer.render(file.template_name)
 
-            if skip_if_exists and self.file_system.file_exists(file.destination_path):
+            already_exists = self.file_system.file_exists(file.destination_path)
+
+            if not already_exists:
+                self.logger.info(f'writing {file.destination_path}')
+            elif skip_if_exists:
                 self.logger.debug(
                     f'skipping {file.destination_path} because it already exists',
                 )
                 continue
+            else:
+                self.logger.warn(f'overwriting {file.destination_path}')
 
             self.file_system.write_file(
                 file.destination_path,

--- a/write_config_files/commands/write.py
+++ b/write_config_files/commands/write.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+from typing import Protocol
+
 import attrs
 
 from ..config import TemplateConfig
-from ..files import FileWriter
 from ..logging import Logger
 from ..rendering import TemplateRenderer
+
+
+class FileSystem(Protocol):
+    def file_exists(self, path: str) -> bool: ...
+    def write_file(self, path: str, content: str, is_executable: bool) -> None: ...
 
 
 @attrs.frozen
 class Writer:
     renderer: TemplateRenderer
-    file_writer: FileWriter
+    file_writer: FileSystem
     logger: Logger
 
     def write(self, templates: TemplateConfig, skip_if_exists: bool) -> None:

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import os.path
-from typing import Protocol
 
 import attrs
 
 from .logging import Logger
-
-
-class Reader(Protocol):
-    def load_file(self, file_path: str) -> list[str]: ...
 
 
 class FileSystemReader:
@@ -19,11 +14,6 @@ class FileSystemReader:
                 return f.readlines()
         except FileNotFoundError:
             return []
-
-
-class FileWriter(Protocol):
-    def file_exists(self, path: str) -> bool: ...
-    def write_file(self, path: str, content: str, is_executable: bool) -> None: ...
 
 
 @attrs.frozen

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -28,11 +28,6 @@ class FileSystem:
             path: str, content: str,
             is_executable: bool,
     ) -> None:
-        if self.file_exists(path):
-            self.logger.warn(f'overwriting {path}')
-        else:
-            self.logger.info(f'writing {path}')
-
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, 'w') as f:
             f.write(content)
@@ -49,7 +44,4 @@ class DryRunFileWriter:
         return os.path.exists(path)
 
     def write_file(self, path: str, content: str, is_executable: bool) -> None:
-        if self.file_exists(path):
-            self.logger.warn(f'would overwrite {path}')
-        else:
-            self.logger.info(f'would write {path}')
+        pass

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -8,7 +8,7 @@ from .logging import Logger
 
 
 class FileSystemReader:
-    def load_file(self, file_path: str) -> list[str]:
+    def read_lines(self, file_path: str) -> list[str]:
         try:
             with open(file_path) as f:
                 return f.readlines()

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -5,15 +5,6 @@ import os.path
 import attrs
 
 
-class FileSystemReader:
-    def read_lines(self, file_path: str) -> list[str]:
-        try:
-            with open(file_path) as f:
-                return f.readlines()
-        except FileNotFoundError:
-            return []
-
-
 @attrs.frozen
 class FileSystem:
     def file_exists(self, path: str) -> bool:
@@ -25,6 +16,9 @@ class FileSystem:
                 return f.read()
         except FileNotFoundError:
             return ''
+
+    def read_lines(self, path: str) -> list[str]:
+        return self.read_content(path).splitlines(keepends=True)
 
     def write_file(
             self,

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -23,6 +23,13 @@ class FileSystem:
     def file_exists(self, path: str) -> bool:
         return os.path.exists(path)
 
+    def read_content(self, path: str) -> str:
+        try:
+            with open(path) as f:
+                return f.read()
+        except FileNotFoundError:
+            return ''
+
     def write_file(
             self,
             path: str, content: str,
@@ -42,6 +49,13 @@ class DryRunFileWriter:
 
     def file_exists(self, path: str) -> bool:
         return os.path.exists(path)
+
+    def read_content(self, path: str) -> str:
+        try:
+            with open(path) as f:
+                return f.read()
+        except FileNotFoundError:
+            return ''
 
     def write_file(self, path: str, content: str, is_executable: bool) -> None:
         pass

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -33,17 +33,6 @@ class FileSystem:
             os.chmod(path, 0o744)
 
 
-@attrs.frozen
-class DryRunFileWriter:
-    def file_exists(self, path: str) -> bool:
-        return os.path.exists(path)
-
-    def read_content(self, path: str) -> str:
-        try:
-            with open(path) as f:
-                return f.read()
-        except FileNotFoundError:
-            return ''
-
+class DryRunFileWriter(FileSystem):
     def write_file(self, path: str, content: str, is_executable: bool) -> None:
         pass

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -4,8 +4,6 @@ import os.path
 
 import attrs
 
-from .logging import Logger
-
 
 class FileSystemReader:
     def read_lines(self, file_path: str) -> list[str]:
@@ -18,8 +16,6 @@ class FileSystemReader:
 
 @attrs.frozen
 class FileSystem:
-    logger: Logger
-
     def file_exists(self, path: str) -> bool:
         return os.path.exists(path)
 
@@ -45,8 +41,6 @@ class FileSystem:
 
 @attrs.frozen
 class DryRunFileWriter:
-    logger: Logger
-
     def file_exists(self, path: str) -> bool:
         return os.path.exists(path)
 

--- a/write_config_files/files.py
+++ b/write_config_files/files.py
@@ -17,7 +17,7 @@ class FileSystemReader:
 
 
 @attrs.frozen
-class OsFileWriter:
+class FileSystem:
     logger: Logger
 
     def file_exists(self, path: str) -> bool:


### PR DESCRIPTION
- Move protocols for use cases to the files that need them
- Rename `load_file` -> `read_lines`
- Rename `OsFileWriter` -> `FileSystem`
- Combine fake reader and writer objects
- Rename `file_writer` -> `file_system`
- Lift logging into command
- Log if dry run
- Do not overwrite files if there is no change necessary
